### PR TITLE
Fix: should use modified PyVerilog from Strider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ func_timeout==4.3.5
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 ply==3.11
-pyverilog==1.3.0
+git+https://github.com/hejy47/Pyverilog.git
 setuptools==60.2.0
 wheel==0.37.1
 pyvcd==0.4.0


### PR DESCRIPTION
official pyverilog==1.3.0 has no `alwaysinfo.clock/reset`